### PR TITLE
Add basic error handling to requests

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -63,8 +63,15 @@ const buildRouter = (admin, predefinedRouter) => {
           res.send(html)
         }
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log(e)
+        if (e.statusCode >= 400 && e.statusCode < 500) {
+          res.status(e.statusCode)
+          res.send({ error: true, status: e.statusCode, notice: e.message })
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(e)
+          res.status(500)
+          res.send({ error: true, status: 500, notice: 'Internal Server Error' })
+        }
       }
     }
 

--- a/plugin.js
+++ b/plugin.js
@@ -65,12 +65,12 @@ const buildRouter = (admin, predefinedRouter) => {
       } catch (e) {
         if (e.statusCode >= 400 && e.statusCode < 500) {
           res.status(e.statusCode)
-          res.send({ error: true, status: e.statusCode, notice: e.message })
+          res.send({ error: true, status: e.statusCode, message: e.message })
         } else {
           // eslint-disable-next-line no-console
           console.error(e)
           res.status(500)
-          res.send({ error: true, status: 500, notice: 'Internal Server Error' })
+          res.send({ error: true, status: 500, message: 'Internal Server Error' })
         }
       }
     }


### PR DESCRIPTION
Previously any error that came from AdminBro would leave the request hanging. This adds actual responses when errors happen. If the error has `statusCode` field it is handled as a client error and the `message` field is sent to the client as `notice`. SoftwareBrothers/admin-bro#309 will display those messages to the user.