### PR TITLE
Session save before redirect

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -160,7 +160,10 @@ const buildAuthenticatedRouter = (admin, auth, predefinedRouter, sessionOptions 
     const adminUser = await auth.authenticate(email, password)
     if (adminUser) {
       req.session.adminUser = adminUser
-      res.redirect(rootPath)
+      req.session.save((err) => {
+        console.error(err)
+        res.redirect(rootPath)
+      })
     } else {
       const login = await admin.renderLogin({
         action: admin.options.loginPath,

--- a/plugin.js
+++ b/plugin.js
@@ -155,13 +155,15 @@ const buildAuthenticatedRouter = (admin, auth, predefinedRouter, sessionOptions 
     res.send(login)
   })
 
-  router.post(loginPath, async (req, res) => {
+  router.post(loginPath, async (req, res, next) => {
     const { email, password } = req.fields
     const adminUser = await auth.authenticate(email, password)
     if (adminUser) {
       req.session.adminUser = adminUser
       req.session.save((err) => {
-        console.error(err)
+        if (err) {
+          next(err)
+        }
         res.redirect(rootPath)
       })
     } else {


### PR DESCRIPTION
fix: Sometimes the session was not saved fast enough and user gets redirected without `adminUser` property in session. That caused redirect back to login.