### PR TITLE
Fixed: Endless redirect with custom rootPath and login module

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -183,8 +183,10 @@ const buildAuthenticatedRouter = (
 
   const { rootPath } = admin.options
   let { loginPath, logoutPath } = admin.options
-  loginPath = loginPath.replace(rootPath, '')
-  logoutPath = logoutPath.replace(rootPath, '')
+  if(AdminBro.DEFAULT_PATHS.rootPath == rootPath) {
+    loginPath = loginPath.replace(rootPath, '')
+    logoutPath = logoutPath.replace(rootPath, '')
+  }
 
   router.get(loginPath, async (req, res) => {
     const login = await admin.renderLogin({


### PR DESCRIPTION
I've made a small adjustment that aims to solve #24. With this fix it's possible to specify a custom `rootPath` without the login ending up in an endless redirect loop. 

This PR only addresses the endless redirect issue, it doesn't address other issues related to the rendering of the login page. I've found that the `loginPath` should still start with the `rootPath` if you want the login page to render. If you have to entirely different paths there, it won't render the page

However, it's a small step forward and it will allow you to use a custom `rootPath` now with the login module :smile: !