### PR TITLE
feat: add typescript declaration module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+import Plugin from './types/index';
+export = Plugin;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "simple": "nodemon examples/simple.js",
     "test": "./node_modules/.bin/mocha spec/index.js",
     "lint": "./node_modules/eslint/bin/eslint.js './examples/**/*.js' './plugin.js'",
+    "type": "tsc",
     "release": "semantic-release"
   },
   "repository": {
@@ -37,10 +38,13 @@
     }
   },
   "devDependencies": {
+    "@admin-bro/mongoose": "^1.0.0",
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "^8.3.4",
+    "@semantic-release/git": "^9.0.0",
     "@types/express": "^4.17.4",
     "@types/mocha": "^7.0.2",
     "admin-bro": ">=3.0.0",
-    "@admin-bro/mongoose": "^1.0.0",
     "chai": "^4.2.0",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
@@ -48,17 +52,16 @@
     "express": "^4.16.4",
     "express-formidable": "^1.2.0",
     "express-session": ">=1.15.6",
+    "husky": "^4.2.5",
     "mocha": "^5.2.0",
     "mongoose": "^5.3.16",
     "nodemon": "^1.18.8",
-    "sinon": "^7.2.3",
-    "sinon-chai": "^3.3.0",
     "semantic-release": "^17.0.7",
     "semantic-release-jira-releases-sb": "^0.7.2",
     "semantic-release-slack-bot": "^1.6.2",
-    "@semantic-release/git": "^9.0.0",
-    "husky": "^4.2.5",
-    "@commitlint/cli": "^8.3.5",
-    "@commitlint/config-conventional": "^8.3.4"
-  }
+    "sinon": "^7.2.3",
+    "sinon-chai": "^3.3.0",
+    "typescript": "^4.0.3"
+  },
+  "dependencies": {}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": ["./index.js", "./plugin.js"],
+  "exclude": ["./types"],
+
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "outDir": "./types"
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,90 @@
+export = Plugin;
+/**
+ * @module @admin-bro/express
+ * @subcategory Plugins
+ * @section modules
+ *
+ * @classdesc
+ * Plugin that allows you to add AdminBro to Express.js applications.
+ *
+ * ## Installation
+ *
+ * ```sh
+ * npm install @admin-bro/express
+ * ```
+ *
+ * It has 2 peerDependencies: `express-formidable` and `express`,
+ * so you have to install them as well (if they are not installed already)
+ *
+ * ```
+ * npm install express express-formidable
+ * ```
+ *
+ * ## Usage
+ *
+ * ```
+ * const AdminBroExpress = require('@admin-bro/express')
+ * ```
+ *
+ * It exposes 2 methods that create an Express Router, which can be attached
+ * to a given url in the API. Each method takes a pre-configured instance of {@link AdminBro}.
+ *
+ * - {@link module:@admin-bro/express.buildRouter AdminBroExpress.buildRouter(admin, [predefinedRouter])}
+ * - {@link module:@admin-bro/express.buildAuthenticatedRouter AdminBroExpress.buildAuthenticatedRouter(admin, auth, [predefinedRouter], sessionOptions)}
+ *
+ * If you want to use a router you have already created - not a problem. Just pass it
+ * as a `predefinedRouter` parameter.
+ *
+ * You may want to use this option when you want to include
+ * some custom auth middleware for you AdminBro routes.
+ *
+ * ## Example without an authentication
+ *
+ * ```
+ * const AdminBro = require('admin-bro')
+ * const AdminBroExpress = require('@admin-bro/express')
+ *
+ * const express = require('express')
+ * const app = express()
+ *
+ * const adminBro = new AdminBro({
+ *   databases: [],
+ *   rootPath: '/admin',
+ * })
+ *
+ * const router = AdminBroExpress.buildRouter(adminBro)
+ * app.use(adminBro.options.rootPath, router)
+ * app.listen(8080, () => console.log('AdminBro is under localhost:8080/admin'))
+ * ```
+ *
+ * ## Using build in authentication
+ *
+ * To protect the routes with a session authentication, you can use predefined
+ * {@link module:@admin-bro/express.buildAuthenticatedRouter} method.
+ *
+ * Note! To use authentication in production environment, there is a need to configure
+ * express-session for production build. It can be achieved by passing options to
+ * `sessionOptions` parameter. Read more on [express/session Github page](https://github.com/expressjs/session)
+ *
+ * ## Adding custom authentication
+ *
+ * You can add your custom authentication setup by firstly creating the router and then
+ * passing it via the `predefinedRouter` option.
+ *
+ * ```
+ * let router = express.Router()
+ * router.use((req, res, next) => {
+ *   if (req.session && req.session.admin) {
+ *     req.session.adminUser = req.session.admin
+ *     next()
+ *   } else {
+ *     res.redirect(adminBro.options.loginPath)
+ *   }
+ * })
+ * router = AdminBroExpress.buildRouter(adminBro, router)
+ * ```
+ *
+ * Where `req.session.admin` is {@link AdminBro#CurrentAdmin},
+ * meaning that it should have at least an email property.
+ */
+declare const Plugin: typeof import("./plugin");

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,0 +1,65 @@
+export type Authenticate = Function;
+/**
+ * Builds the Express Router that handles all the pages and assets
+ *
+ * @param  {AdminBro} admin                       instance of AdminBro
+ * @param  {express.Router} [predefinedRouter]    Express.js router
+ * @param  {ExpressFormidableOptions} [formidableOptions]    Express.js router
+ * @return {express.Router}                       Express.js router
+ * @function
+ * @static
+ * @memberof module:@admin-bro/express
+ */
+export function buildRouter(admin: typeof import("admin-bro"), predefinedRouter?: import("express").Router, formidableOptions?: any): import("express").Router;
+/**
+ * @typedef {Function} Authenticate
+ * @memberof module:@admin-bro/express
+ * @description
+ * function taking 2 arguments email and password
+ * @param {string} [email]         email given in the form
+ * @param {string} [password]      password given in the form
+ * @return {CurrentAdmin | null}      returns current admin or null
+ */
+/**
+ * Builds the Express Router which is protected by a session auth
+ *
+ * Using the router requires you to install `express-session` as a
+ * dependency. Normally express-session holds session in memory, which is
+ * not optimized for production usage and, in development, it causes
+ * logging out after every page refresh (if you use nodemon).
+ *
+ * @param  {AdminBro} admin                    instance of AdminBro
+ * @param  {Object} auth                          authentication options
+ * @param  {module:@admin-bro/express.Authenticate} auth.authenticate       authenticate function
+ * @param  {String} auth.cookiePassword           secret used to encrypt cookies
+ * @param  {String} auth.cookieName=adminbro      cookie name
+ * @param  {express.Router} [predefinedRouter]    Express.js router
+ * @param  {SessionOptions} [sessionOptions]     Options that are passed to [express-session](https://github.com/expressjs/session)
+ * @param  {ExpressFormidableOptions} [formidableOptions]     Options that are passed to [express-session](https://github.com/expressjs/session)
+ * @return {express.Router}                       Express.js router
+ * @static
+ * @memberof module:@admin-bro/express
+ * @example
+ * const ADMIN = {
+ *   email: 'test@example.com',
+ *   password: 'password',
+ * }
+ *
+ * AdminBroExpress.buildAuthenticatedRouter(adminBro, {
+ *   authenticate: async (email, password) => {
+ *     if (ADMIN.password === password && ADMIN.email === email) {
+ *       return ADMIN
+ *     }
+ *     return null
+ *   },
+ *   cookieName: 'adminbro',
+ *   cookiePassword: 'somePassword',
+ * }, [router])
+ */
+export function buildAuthenticatedRouter(admin: typeof import("admin-bro"), auth: {
+    authenticate: any;
+    cookiePassword: string;
+    cookieName: string;
+}, predefinedRouter?: import("express").Router, sessionOptions?: any, formidableOptions?: any): import("express").Router;
+export declare const version: any;
+export declare const name: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9034,6 +9034,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
 uglify-js@^3.1.4:
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.4.tgz#867402377e043c1fc7b102253a22b64e5862401b"


### PR DESCRIPTION
Hello,
I think this library needs typescript module. So, I added it.
It generate `.d.ts` file with `tsconfig.json` and `tsc`.

- Add script `yarn type`. It creates typescript declaration at `./types` directory

- Add add `index.d.ts` at root path. It exports the `d.ts` module in `./types`

I don't know how to run `yarn type` automatically at deploy process.
But, You can tell me, and I can add commits or you can just merge this.

Please review my code.
