### PR TITLE
fix(login): explicitly use 302 status while redirecting POST request

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -139,11 +139,11 @@ const buildRouter = (admin, predefinedRouter, formidableOptions) => {
  * }, [router])
  */
 const buildAuthenticatedRouter = (
-  admin,
-  auth,
-  predefinedRouter,
-  sessionOptions = {},
-  formidableOptions = {},
+    admin,
+    auth,
+    predefinedRouter,
+    sessionOptions = {},
+    formidableOptions = {},
 ) => {
   if (!session) {
     throw new Error(['In order to use authentication, you have to install',
@@ -211,9 +211,9 @@ const buildAuthenticatedRouter = (
           next(err)
         }
         if (req.session.redirectTo) {
-          res.redirect(req.session.redirectTo)
+          res.redirect(302, req.session.redirectTo)
         } else {
-          res.redirect(rootPath)
+          res.redirect(302, rootPath)
         }
       })
     } else {

--- a/plugin.js
+++ b/plugin.js
@@ -139,11 +139,11 @@ const buildRouter = (admin, predefinedRouter, formidableOptions) => {
  * }, [router])
  */
 const buildAuthenticatedRouter = (
-    admin,
-    auth,
-    predefinedRouter,
-    sessionOptions = {},
-    formidableOptions = {},
+  admin,
+  auth,
+  predefinedRouter,
+  sessionOptions = {},
+  formidableOptions = {},
 ) => {
   if (!session) {
     throw new Error(['In order to use authentication, you have to install',


### PR DESCRIPTION
Closes #34 

this is because destination path - either from `req.session.redirectTo` or `rootPath` might not handle POST request, most likely it will be either "home" page or maybe a previous route.