### PR TITLE
Turn off tslib require when compiling ts files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "target": "es2017",
     "jsx": "preserve",
-    "importHelpers": true,
+    "importHelpers": false,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Fixes https://github.com/SoftwareBrothers/admin-bro/issues/772

Rather than adding more deps, the tslib `__importDefault` can just be inserted directly to avoid this problem.  